### PR TITLE
Support for the new Sailing trees

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.creativetechguy'
-version = '1.4.8'
+version = '1.5.0'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/src/main/java/com/creativetechguy/TreeConfig.java
+++ b/src/main/java/com/creativetechguy/TreeConfig.java
@@ -24,9 +24,12 @@ public enum TreeConfig {
             new int[]{ObjectID.YEW_TREE_10822, NullObjectID.NULL_10823,
                     // 10828 = Lumbridge Graveyard tree
                     NullObjectID.NULL_10828, ObjectID.YEW_TREE_36683, ObjectID.YEW_TREE_40756, ObjectID.YEW_TREE_42391}),
+    CAMPHOR(60 * 2, new int[]{ObjectID.CAMPHOR_TREE}),
     MAGIC(60 * 3 + 54, new int[]{ObjectID.MAGIC_TREE_10834, NullObjectID.NULL_10835}),
+    IRONWOOD(60 * 4, new int[]{ObjectID.IRONWOOD_TREE}),
     REDWOOD(60 * 4 + 24,
-            new int[]{ObjectID.REDWOOD_TREE, ObjectID.REDWOOD_TREE_29670});
+            new int[]{ObjectID.REDWOOD_TREE, ObjectID.REDWOOD_TREE_29670}),
+    ROSEWOOD(60 * 4 + 35, new int[]{ObjectID.ROSEWOOD_TREE});
 
     private static final ArrayList<Integer> blockedRegions = new ArrayList<>(List.of(
             // Miscellania

--- a/src/main/java/com/creativetechguy/TreeConfig.java
+++ b/src/main/java/com/creativetechguy/TreeConfig.java
@@ -24,7 +24,7 @@ public enum TreeConfig {
             new int[]{ObjectID.YEW_TREE_10822, NullObjectID.NULL_10823,
                     // 10828 = Lumbridge Graveyard tree
                     NullObjectID.NULL_10828, ObjectID.YEW_TREE_36683, ObjectID.YEW_TREE_40756, ObjectID.YEW_TREE_42391}),
-    CAMPHOR(60 * 2, new int[]{ObjectID.CAMPHOR_TREE}),
+    CAMPHOR(60 + 54, new int[]{ObjectID.CAMPHOR_TREE}),
     MAGIC(60 * 3 + 54, new int[]{ObjectID.MAGIC_TREE_10834, NullObjectID.NULL_10835}),
     IRONWOOD(60 * 3 + 54, new int[]{ObjectID.IRONWOOD_TREE}),
     REDWOOD(60 * 4 + 24,

--- a/src/main/java/com/creativetechguy/TreeConfig.java
+++ b/src/main/java/com/creativetechguy/TreeConfig.java
@@ -26,10 +26,10 @@ public enum TreeConfig {
                     NullObjectID.NULL_10828, ObjectID.YEW_TREE_36683, ObjectID.YEW_TREE_40756, ObjectID.YEW_TREE_42391}),
     CAMPHOR(60 * 2, new int[]{ObjectID.CAMPHOR_TREE}),
     MAGIC(60 * 3 + 54, new int[]{ObjectID.MAGIC_TREE_10834, NullObjectID.NULL_10835}),
-    IRONWOOD(60 * 4, new int[]{ObjectID.IRONWOOD_TREE}),
+    IRONWOOD(60 * 3 + 54, new int[]{ObjectID.IRONWOOD_TREE}),
     REDWOOD(60 * 4 + 24,
             new int[]{ObjectID.REDWOOD_TREE, ObjectID.REDWOOD_TREE_29670}),
-    ROSEWOOD(60 * 4 + 35, new int[]{ObjectID.ROSEWOOD_TREE});
+    ROSEWOOD(60 * 4 + 24, new int[]{ObjectID.ROSEWOOD_TREE});
 
     private static final ArrayList<Integer> blockedRegions = new ArrayList<>(List.of(
             // Miscellania


### PR DESCRIPTION
I apologize if you don't want outside contributions to the plugin, but I've been loving it for a long time and wanted it to work for the new Sailing trees. Since the tree cutting times are now officially revealed, I added the trees with the despawn timers from the Wiki. 
The Rosewood Tree still only states that it's an estimated 274.8 Seconds, so I set it to be 275 seconds in the config. I cut down a few trees and the 275 second timer seemed to be accurate

<img width="272" height="225" alt="Camphor" src="https://github.com/user-attachments/assets/d5b054d2-0ba5-403a-a287-ff4b1cc68dc2" />
<img width="349" height="331" alt="RoseWood" src="https://github.com/user-attachments/assets/47410447-3fd0-4e71-99d6-b53c147f1769" />
